### PR TITLE
install/uninstall css changes

### DIFF
--- a/aimlbotkernel/__init__.py
+++ b/aimlbotkernel/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 KERNEL_NAME = 'aimlbot'
 LANGUAGE = 'chatbot'

--- a/aimlbotkernel/install.py
+++ b/aimlbotkernel/install.py
@@ -35,6 +35,11 @@ kernel_json = {
 
 # --------------------------------------------------------------------------
 
+def css_frame_prefix( name ):
+    '''Define the comment prefix used in custom css to frame kernel CSS'''
+    return '/* @{{KERNEL}} {} '.format(name)
+
+
 def copyresource( resource, filename, destdir ):
     """
     Copy a resource file to a destination
@@ -58,30 +63,28 @@ def install_kernel_resources( destdir, resource=PKGNAME, files=None ):
             sys.stderr.write(str(e))
 
 
-def install_custom_css(destdir, cssfile, resource=PKGNAME ):
+def install_custom_css( destdir, cssfile, resource=PKGNAME ):
     """
     Install the kernel CSS file and include it within custom.css
     """
-    # Copy it
     ensure_dir_exists( destdir )
-    cssfile += '.css'
-    copyresource( resource, cssfile, destdir )
+    prefix = css_frame_prefix(resource)
 
     # Check if custom.css already includes it. If so, we can return
-    include = "@import url('{}');".format( cssfile )
     custom = os.path.join( destdir, 'custom.css' )
     if os.path.exists( custom ):
         with open(custom) as f:
             for line in f:
-                if line.find( include ) >= 0:
+                if line.find( prefix ) >= 0:
                     return
 
-    # Add the import line at the beginning of custom.css
-    prefix = '/* KERNEL: {} '.format(resource)
+    # Add the CSS at the beginning of custom.css
+    cssfile += '.css'
+    data = pkgutil.get_data( resource, os.path.join('resources',cssfile) )
     with open(custom + '-new', 'w') as fout:
-        fout.write('{}START --------- */\n'.format(prefix))
-        fout.write( include + '\n' )
-        fout.write('{}END ----------- */\n\n'.format(prefix))
+        fout.write('{}START ======================== */\n'.format(prefix))
+        fout.write( data )
+        fout.write('{}END ======================== */\n'.format(prefix))
         if os.path.exists( custom ):
             with open( custom ) as fin:
                 for line in fin:
@@ -89,34 +92,31 @@ def install_custom_css(destdir, cssfile, resource=PKGNAME ):
     os.rename( custom+'-new',custom)
 
 
-def remove_custom_css(destdir, cssfile, resource=PKGNAME ):
+def remove_custom_css(destdir, resource=PKGNAME ):
     """
     Remove the kernel CSS file and eliminat its include in custom.css
     """
-    fullname = os.path.join( destdir, cssfile )
-    if not fullname.endswith('.css'):
-        fullname += '.css'
-    
-    if not os.path.exists( fullname ):
-        return False
 
     # Remove the inclusion in the main CSS
     custom = os.path.join( destdir, 'custom.css' )
     copy = True
-    prefix = '/* KERNEL: {} '.format(resource)
+    found = False
+    prefix = css_frame_prefix(resource)
     with open(custom + '-new', 'w') as fout:
         with open(custom) as fin:
             for line in fin:
                 if line.startswith( prefix + 'START' ):
                     copy = False
+                    found = True
                 elif line.startswith( prefix + 'END' ):
                     copy = True
                 elif copy:
                     fout.write( line )
-    os.rename( custom+'-new',custom)
 
-    # Remove the CSS file
-    os.remove( fullname )
+    if found:
+        os.rename( custom+'-new',custom)
+    else:
+        os.unlink( custom+'-new')
 
     return True
 

--- a/aimlbotkernel/resources/aimlbotkernel.css
+++ b/aimlbotkernel/resources/aimlbotkernel.css
@@ -1,5 +1,4 @@
-/* ------------------------------------------------------------------------- */
-/* CSS styles for the AIML Chatbot kernel */
+/* ------ CSS styles for the AIML Chatbot kernel ------ */
 
 
 /* Responses from the bot */
@@ -70,4 +69,3 @@ div.krn-bot div.error span.title {
     color: red; font-weight: bold;
 }
 
-/* ------------------------------------------------------------------------- */


### PR DESCRIPTION
- kernel css inserted inside `custom.css`, instead of importing. This enables keeping it when converting the notebook
- string used to frame the inserted CSS changed
